### PR TITLE
Added option, support for pointing to client bucket path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,19 @@ or more of these older versions.
 
 Run the script like this:
 
-    clientbucket.rb /path/to/file
+    clientbucket.rb -t /path/to/file -c path/to/client/bucket
 
-Where /path/to/file is the file on the system that you're looking for old versions of.
+Where /path/to/file is the file on the system that you're looking for old versions of. If you run it by itself, it will return the following help screen:
+
+    Usage: clientbucket.rb -t target_path -c clientbucket_path
+        -t, --target_path target_path    path of the file to restore
+        -c clientbucket_path,            where to restore from. Defaults to /var/lib/puppet/clientbucket
+            --clientbucket_path
+        -h, --help  
 
 The script runs interactively and prompts you for what you want to do. An example:
 
-    # clientbucket.rb /some/test/file
+    # clientbucket.rb -t /some/test/file
     [0]: 41f59421026a473a0378c58d539069c6 Thu Feb 09 15:56:36 +0000 2012
     [1]: 6bc6ab38660066ea8cf0743b889bd075 Mon Feb 20 15:23:59 +0000 2012
     [2]: 74da6d605bfd7ecad38904bc35a0292a Thu May 24 13:45:10 +0100 2012

--- a/clientbucket.rb
+++ b/clientbucket.rb
@@ -4,7 +4,7 @@ require 'rubygems'
 require 'find'
 
 if ARGV.length < 1
-  puts "Usage: clientbucket.rb /path/to/file"
+  puts "Usage: clientbucket.rb /path/to/file /path/to/clientbucket"
   exit 1
 end
 

--- a/clientbucket.rb
+++ b/clientbucket.rb
@@ -13,34 +13,37 @@ clientbucket_path ||= "/var/lib/puppet/clientbucket"
 
 available_files = Array.new
 
-Find.find(clientbucket_path) do |file_path|
+begin
+  Find.find(clientbucket_path) do |file_path|
 
-  # Skip directories and "contents" files
-  next if FileTest.directory?(file_path)
-  next unless File.basename(file_path) =~ /paths$/
+    # Skip directories and "contents" files
+    next if FileTest.directory?(file_path)
+    next unless File.basename(file_path) =~ /paths$/
 
-  # See if this file has a path the user was looking for
-  path = File.open(file_path).first
-  path.chomp!
-  if target_path == path
+    # See if this file has a path the user was looking for
+    path = File.open(file_path).first
+    path.chomp!
+    if target_path == path
 
-    # Get the md5 string the file is referred to by
-    file_path =~ /([^\/]+)\/paths$/;
-    file_hash = $1
+      # Get the md5 string the file is referred to by
+      file_path =~ /([^\/]+)\/paths$/;
+      file_hash = $1
 
-    # Get the "contents" file containing the old file's contents
-    contents_path = File.dirname(file_path) + "/contents"
+      # Get the "contents" file containing the old file's contents
+      contents_path = File.dirname(file_path) + "/contents"
 
-    # Get the creation time
-    ctime = File.stat(file_path).ctime
+      # Get the creation time
+      ctime = File.stat(file_path).ctime
 
-    details = {:hash => file_hash, :ctime => ctime, :contents_path => contents_path}
-    available_files.push(details)
+      details = {:hash => file_hash, :ctime => ctime, :contents_path => contents_path}
+      available_files.push(details)
+
+    end
 
   end
-
+rescue
+  puts "Unable to open file path #{clientbucket_path}"
 end
-
 # See if we found any files for the user
 if available_files.length == 0
   puts "No files with path #{target_path} exist in the clientbucket"

--- a/clientbucket.rb
+++ b/clientbucket.rb
@@ -8,8 +8,8 @@ if ARGV.length < 1
   exit 1
 end
 
-target_path = ARGV.shift
-clientbucket_path = "/var/lib/puppet/clientbucket"
+target_path,clientbucket_path = ARGV
+clientbucket_path ||= "/var/lib/puppet/clientbucket"
 
 available_files = Array.new
 

--- a/clientbucket.rb
+++ b/clientbucket.rb
@@ -2,14 +2,36 @@
 
 require 'rubygems'
 require 'find'
+require 'optparse'
 
-if ARGV.length < 1
-  puts "Usage: clientbucket.rb /path/to/file /path/to/clientbucket"
-  exit 1
+options = {:target_path => nil, :clientbucket_path => nil}
+parser = OptionParser.new do |opts|
+  opts.banner = "Usage: clientbucket.rb -t target_path -c clientbucket_path"
+  
+  opts.on("-t", "--target_path target_path", "path to file to restore") do |t|
+    options[:target_path] = t
+  end
+
+  opts.on("-c", "--clientbucket_path clientbucket_path", "path to file to restore") do |c|
+    options[:clientbucket_path] = c
+  end
 end
 
-target_path,clientbucket_path = ARGV
-clientbucket_path ||= "/var/lib/puppet/clientbucket"
+parser.parse!
+
+if options[:target_path] == nil
+  print 'Enter target path: '
+  options[:target_path] = gets.chomp
+end
+
+if options[:clientbucket_path] == nil
+  print 'Enter clientbucket path: '
+  options[:clientbucket_path] = gets.chomp
+end
+
+target_path = options[:target_path]
+
+clientbucket_path =  options[:clientbucket_path]
 
 available_files = Array.new
 


### PR DESCRIPTION
- I changed it over to optionparser, to allow manipulation of the arguemnts
- Also, since the path to Clientbucket has changed with Puppet 4, I added an option to allow the user to point to a different path to the bucket. To ensure backwards compatibility, it defaults to the old path (Puppet 3.x and earlier).
